### PR TITLE
Add support for Xcode 13.1 & improve highlighting

### DIFF
--- a/TypeScript.ideplugin/Contents/Info.plist
+++ b/TypeScript.ideplugin/Contents/Info.plist
@@ -35,6 +35,7 @@
 		<string>C3998872-68CC-42C2-847C-B44D96AB2691</string>
 		<string>B395D63E-9166-4CD6-9287-6889D507AD6A</string>
 		<string>D7881182-AD00-4C36-A94D-F45FC9B0CF85</string>
+		<string>8BAA96B4-5225-471B-B124-D32A349B8106</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>

--- a/TypeScript.xclangspec
+++ b/TypeScript.xclangspec
@@ -11,6 +11,8 @@
             StartChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
             Chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
             Words = (
+                "async",
+                "await",
                 "break",
                 "case",
                 "catch",
@@ -33,6 +35,7 @@
                 "import",
                 "in",
                 "instanceof",
+                "interface",
                 "new",
                 "null",
                 "return",
@@ -69,7 +72,7 @@
             Tokenizer = "xcode.lang.typescript.lexer";
             IncludeRules = (
                 "xcode.lang.typescript.function",
-				"xcode.lang.typescript.function.closure",
+                "xcode.lang.typescript.function.closure",
                 "xcode.lang.typescript.block",
                 "xcode.lang.typescript.bracketexpr",
                 "xcode.lang.typescript.parenexpr",
@@ -77,7 +80,7 @@
             Type = "xcode.syntax.plain";
         };
     },
-    
+
     // The following rule returns tokens to the other rules
     {
         Identifier = "xcode.lang.typescript.lexer";
@@ -92,7 +95,7 @@
             );
         };
     },
-    
+
     {
         Identifier = "xcode.lang.typescript.function";
         Syntax = {
@@ -104,7 +107,7 @@
             Type = "xcode.syntax.definition.function";
         };
     },
-    
+
      {
         Identifier = "xcode.lang.typescript.function.declarator";
         Syntax = {
@@ -116,7 +119,7 @@
             );
         };
     },
-    
+
     {
         Identifier = "xcode.lang.typescript.function.closure";
         Syntax = {
@@ -128,44 +131,44 @@
             Type = "xcode.syntax.definition.function";
         };
     },
-    
+
      {
         Identifier = "xcode.lang.typescript.function.closure.declarator";
         Syntax = {
             Tokenizer = "xcode.lang.typescript.lexer";
             Rules = (
                 "xcode.lang.typescript.function.name",
-				"=",
+                "=",
                 "function",
                 "xcode.lang.typescript.parenexpr",
             );
         };
     },
-    
+
     {
         Identifier = "xcode.lang.typescript.function.name";
         Syntax = {
             Tokenizer = "xcode.lang.typescript.lexer";
             Rules = (
                 "xcode.lang.typescript.identifier",
-				"xcode.lang.typescript.function.name.more*",
+                "xcode.lang.typescript.function.name.more*",
             );
             Type = "xcode.syntax.name.partial";
         };
     },
-    
+
     {
         Identifier = "xcode.lang.typescript.function.name.more";
         Syntax = {
             Tokenizer = "xcode.lang.typescript.lexer";
             Rules = (
                 ".",
-				"xcode.lang.typescript.identifier",
+                "xcode.lang.typescript.identifier",
             );
             Type = "xcode.syntax.name.partial";
         };
     },
-    
+
     {
         Identifier = "xcode.lang.typescript.block";
         Syntax = {
@@ -176,7 +179,7 @@
             Recursive = YES;
             IncludeRules = (
                 "xcode.lang.typescript.function",
-				"xcode.lang.typescript.function.closure",
+                "xcode.lang.typescript.function.closure",
                 "xcode.lang.typescript.bracketexpr",
                 "xcode.lang.typescript.parenexpr",
             );


### PR DESCRIPTION
The need todo some TypeScript occurred at work, so I did some googling and found this repo. Minor details that needed fixing so… this is what I came up with and just wanted to share it.

- Add Xcode 13.1 UUID to plugin
- Add `async`, `await` & `interface` to keyword highlighting